### PR TITLE
Fixed Recent AMI Image Logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -284,7 +284,11 @@ function prepareInstanceSummary(_instanceList, _snapshotList, _amiList) {
             return b.daysOld - a.daysOld;
         });
 
-        if (inst.hasImage) inst.recentAMIAge = inst.amis[0].daysOld;
+         if(inst.hasImage) {
+            inst.recentAMIAge =inst.amis[inst.amis.length-1].daysOld;
+            inst.amiDetail=inst.amis[inst.amis.length-1];
+            inst.amis=[inst.amiDetail];
+        }
 
     });
 


### PR DESCRIPTION
Fixed Recent AMI Image Logic by considering only the recent AMI Image.  Simulated Locally and Verified.
Example : Instance 1 has 2 AMI Images which is 5 days old and 45 days Old.
In this case that Instance will be listed in the < tha 30 days old Section. That instance will not come in the > 30 days Section.